### PR TITLE
feat: add .NET 8 support to production packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
+### Security
 ### Added
+- Added .NET 8 support to production packages
 ### Fixed
 ### Changed
+### Deprecated
 ### Removed
 ### Deployment Changes
-
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->

--- a/db/postgresql/pgsql.schema.sql
+++ b/db/postgresql/pgsql.schema.sql
@@ -4,57 +4,57 @@ SET QUOTED_IDENTIFIER ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 SELECT @@VERSION;
-    -- create schema if not exists ethereum;
-    --
-    -- create table if not exists ethereum.account
-    -- (
-    --   id      serial
-    --   constraint account_pk
-    --   primary key,
-    --   name    varchar(200) not null,
-    --   address char(42)     not null
-    --   );
-    --
-    -- alter table ethereum.account
-    --   owner to markr;
-    --
-    -- create or replace function account_get(id integer)
-    --     returns TABLE(id integer, name text, address character)
-    --     language sql
-    -- as
-    -- $$
-    -- SELECT a.id, a.name, a.address from ethereum.account a where a.id = account_get.id;
-    -- $$;
-    --
-    -- alter function ethereum.account_get(integer) owner to markr;
-    --
-    -- create or replace function ethereum.account_getall(address character)
-    --     returns TABLE(id integer, name text, address character)
-    --     language sql
-    -- as
-    -- $$
-    -- SELECT a.id, a.name, a.address from ethereum.account a where a.address = account_getall.address;
-    -- $$;
-    --
-    -- alter function ethereum.account_getall(char) owner to markr;
-    --
-    -- create or replace procedure ethereum.account_insert(IN name character varying, IN address character)
-    --     language sql
-    -- as
-    -- $$
-    --     INSERT INTO ethereum.account (name, address)
-    --     VALUES (account_insert.name, account_insert.address);
-    -- $$;
-    --
-    -- alter procedure ethereum.account_insert(varchar, char) owner to markr;
-    --
-    --
-    -- create or replace function ethereum.get_meaning_of_life_universe_and_everything()
-    --   returns int
-    --   language sql
-    -- AS
-    -- $$
-    -- SELECT 42;
-    -- $$;
-    --
-    -- alter procedure ethereum.get_meaning_of_life_universe_and_everything() owner to markr;
+-- create schema if not exists ethereum;
+--
+-- create table if not exists ethereum.account
+-- (
+--   id      serial
+--   constraint account_pk
+--   primary key,
+--   name    varchar(200) not null,
+--   address char(42)     not null
+--   );
+--
+-- alter table ethereum.account
+--   owner to markr;
+--
+-- create or replace function account_get(id integer)
+--     returns TABLE(id integer, name text, address character)
+--     language sql
+-- as
+-- $$
+-- SELECT a.id, a.name, a.address from ethereum.account a where a.id = account_get.id;
+-- $$;
+--
+-- alter function ethereum.account_get(integer) owner to markr;
+--
+-- create or replace function ethereum.account_getall(address character)
+--     returns TABLE(id integer, name text, address character)
+--     language sql
+-- as
+-- $$
+-- SELECT a.id, a.name, a.address from ethereum.account a where a.address = account_getall.address;
+-- $$;
+--
+-- alter function ethereum.account_getall(char) owner to markr;
+--
+-- create or replace procedure ethereum.account_insert(IN name character varying, IN address character)
+--     language sql
+-- as
+-- $$
+--     INSERT INTO ethereum.account (name, address)
+--     VALUES (account_insert.name, account_insert.address);
+-- $$;
+--
+-- alter procedure ethereum.account_insert(varchar, char) owner to markr;
+--
+--
+-- create or replace function ethereum.get_meaning_of_life_universe_and_everything()
+--   returns int
+--   language sql
+-- AS
+-- $$
+-- SELECT 42;
+-- $$;
+--
+-- alter procedure ethereum.get_meaning_of_life_universe_and_everything() owner to markr;

--- a/src/Credfeto.Database.Interfaces/Credfeto.Database.Interfaces.csproj
+++ b/src/Credfeto.Database.Interfaces/Credfeto.Database.Interfaces.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Pgsql/Credfeto.Database.Pgsql.csproj
+++ b/src/Credfeto.Database.Pgsql/Credfeto.Database.Pgsql.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Source.Generation.Example/Credfeto.Database.Source.Generation.Example.csproj
+++ b/src/Credfeto.Database.Source.Generation.Example/Credfeto.Database.Source.Generation.Example.csproj
@@ -40,7 +40,7 @@
     <Product>Database wrapper</Product>
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.SqlServer/Credfeto.Database.SqlServer.csproj
+++ b/src/Credfeto.Database.SqlServer/Credfeto.Database.SqlServer.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database/Credfeto.Database.csproj
+++ b/src/Credfeto.Database/Credfeto.Database.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generator</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

- Add `net8.0` to `TargetFrameworks` for all production library projects
- Test projects remain at `net9.0;net10.0` — `FunFair.Test.Common` does not yet publish net8.0 support
- Build, buildcheck, and tests all pass

Closes #14