### PR TITLE
docs: add usage examples to README covering model, mapper, and SqlObjectMap attribute patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 - BenchmarkDotNet performance benchmark project for the database source code generator
+- Add usage examples to README covering model, mapper, and SqlObjectMap attribute patterns (#12)
 ### Fixed
 - Fixed SQLFLUFF LT02 indentation violations in pgsql.schema.sql
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ to run.
 
 ```xml
 <ItemGroup>
-  <PackageReference 
-            Include="Credfeto.Database.Source.Generation" 
-            Version="1.1.1.1" 
-            PrivateAssets="All" 
+  <PackageReference
+            Include="Credfeto.Database.Source.Generation"
+            Version="1.1.1.1"
+            PrivateAssets="All"
             ExcludeAssets="runtime" />
 </ItemGroup>
 ```
@@ -25,10 +25,111 @@ generator.
     <PackageReference
             Include="Credfeto.Database.Interfaces"
             Version="1.1.1.1"
-            PrivateAssets="All" 
+            PrivateAssets="All"
             ExcludeAssets="runtime" />
 </ItemGroup>
 ```
+
+## Usage
+
+### 1. Define a result model
+
+Create a record (or class) whose property names match the database column names. Use `[SqlFieldMap<TMapper, TType>]`
+on any property that requires custom type conversion:
+
+```csharp
+using Credfeto.Database.Interfaces;
+
+public sealed record Accounts(
+    int Id,
+    string Name,
+    [SqlFieldMap<AccountAddressMapper, AccountAddress>] AccountAddress Address,
+    DateTime LastModified
+);
+```
+
+### 2. Implement a mapper (for custom types)
+
+Implement `IMapper<T>` to control how a custom type is read from / written to the database:
+
+```csharp
+using System.Data;
+using System.Data.Common;
+using Credfeto.Database.Interfaces;
+
+internal sealed class AccountAddressMapper : IMapper<AccountAddress>
+{
+    public static AccountAddress MapFromDb(object value) =>
+        new() { Value = (string)value };
+
+    public static void MapToDb(AccountAddress value, DbParameter parameter)
+    {
+        parameter.Value = value.Value;
+        parameter.DbType = DbType.String;
+        parameter.Size = 100;
+    }
+}
+```
+
+### 3. Declare the database wrapper
+
+Create an `internal static partial` class and annotate each method with `[SqlObjectMap]`. The generator fills
+in the implementation at compile time:
+
+```csharp
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Database.Interfaces;
+
+internal static partial class DatabaseWrapper
+{
+    // Table-valued function — returns multiple rows
+    [SqlObjectMap(name: "schema.account_getall",
+        sqlObjectType: SqlObjectType.TABLE_FUNCTION,
+        sqlDialect: SqlDialect.GENERIC)]
+    public static partial ValueTask<IReadOnlyList<Accounts>> GetAllAsync(
+        DbConnection connection,
+        [SqlFieldMap<AccountAddressMapper, AccountAddress>] AccountAddress address,
+        CancellationToken cancellationToken);
+
+    // Stored procedure — no return value
+    [SqlObjectMap(name: "schema.account_insert",
+        sqlObjectType: SqlObjectType.STORED_PROCEDURE,
+        sqlDialect: SqlDialect.GENERIC)]
+    public static partial ValueTask InsertAsync(
+        DbConnection connection,
+        string name,
+        [SqlFieldMap<AccountAddressMapper, AccountAddress>] AccountAddress address,
+        CancellationToken cancellationToken);
+
+    // Scalar function — returns a single value
+    [SqlObjectMap(name: "schema.get_meaning_of_life",
+        sqlObjectType: SqlObjectType.SCALAR_FUNCTION,
+        sqlDialect: SqlDialect.GENERIC)]
+    public static partial ValueTask<int> GetMeaningOfLifeAsync(
+        DbConnection connection,
+        CancellationToken cancellationToken);
+}
+```
+
+Supported `SqlObjectType` values: `TABLE_FUNCTION`, `STORED_PROCEDURE`, `SCALAR_FUNCTION`.
+Supported `SqlDialect` values: `GENERIC`, `MICROSOFT_SQL_SERVER`.
+
+### 4. What the generator produces
+
+For each annotated method the generator emits a complete implementation in a `*.generated.cs` file. For example,
+`GetAllAsync` above produces code that:
+
+- builds a `DbCommand` with the appropriate SQL (`SELECT … FROM schema.account_getall(@address)`),
+- maps each input parameter (calling `AccountAddressMapper.MapToDb` for custom types),
+- executes the reader and maps each result row back to an `Accounts` record (calling
+  `AccountAddressMapper.MapFromDb` for custom types),
+- returns the results as `IReadOnlyList<Accounts>`.
+
+You never write this boilerplate by hand — the generator keeps it in sync with your method signatures
+automatically.
 
 ## Viewing Compiler Generated files
 


### PR DESCRIPTION
## Summary

- Add `## Usage` section to README with step-by-step examples: define a result model, implement a custom type mapper, declare the `static partial` database wrapper class with `[SqlObjectMap]`-annotated methods, and description of what the generator produces
- Covers all three `SqlObjectType` values: `TABLE_FUNCTION`, `STORED_PROCEDURE`, `SCALAR_FUNCTION`

Closes #12

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Code examples match the actual generator attributes and patterns