### PR TITLE
build: drop net9.0, target net10.0 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
+- Dropped net9.0 support: projects now target net10.0 only
 ### Removed
 ### Deployment Changes
 <!--

--- a/src/Credfeto.Database.Interfaces.Tests/Credfeto.Database.Interfaces.Tests.csproj
+++ b/src/Credfeto.Database.Interfaces.Tests/Credfeto.Database.Interfaces.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.Interfaces/Credfeto.Database.Interfaces.csproj
+++ b/src/Credfeto.Database.Interfaces/Credfeto.Database.Interfaces.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Pgsql.Tests/Credfeto.Database.Pgsql.Tests.csproj
+++ b/src/Credfeto.Database.Pgsql.Tests/Credfeto.Database.Pgsql.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.Pgsql/Credfeto.Database.Pgsql.csproj
+++ b/src/Credfeto.Database.Pgsql/Credfeto.Database.Pgsql.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Source.Generation.Benchmark.Tests/Credfeto.Database.Source.Generation.Benchmark.Tests.csproj
+++ b/src/Credfeto.Database.Source.Generation.Benchmark.Tests/Credfeto.Database.Source.Generation.Benchmark.Tests.csproj
@@ -29,7 +29,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.Source.Generation.Example.Tests/Credfeto.Database.Source.Generation.Example.Tests.csproj
+++ b/src/Credfeto.Database.Source.Generation.Example.Tests/Credfeto.Database.Source.Generation.Example.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.Source.Generation.Example/Credfeto.Database.Source.Generation.Example.csproj
+++ b/src/Credfeto.Database.Source.Generation.Example/Credfeto.Database.Source.Generation.Example.csproj
@@ -40,7 +40,7 @@
     <Product>Database wrapper</Product>
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Source.Generation.Tests/Credfeto.Database.Source.Generation.Tests.csproj
+++ b/src/Credfeto.Database.Source.Generation.Tests/Credfeto.Database.Source.Generation.Tests.csproj
@@ -29,7 +29,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.SqlServer.Tests/Credfeto.Database.SqlServer.Tests.csproj
+++ b/src/Credfeto.Database.SqlServer.Tests/Credfeto.Database.SqlServer.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database.SqlServer/Credfeto.Database.SqlServer.csproj
+++ b/src/Credfeto.Database.SqlServer/Credfeto.Database.SqlServer.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generation</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Database.Tests/Credfeto.Database.Tests.csproj
+++ b/src/Credfeto.Database.Tests/Credfeto.Database.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Database/Credfeto.Database.csproj
+++ b/src/Credfeto.Database/Credfeto.Database.csproj
@@ -44,7 +44,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-database-source-generator</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

Drops `net9.0` from all multi-targeted projects so they target `net10.0` exclusively, per the approved implementation plan on issue #170.

- Replace `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>` with `<TargetFramework>net10.0</TargetFramework>` in every affected `.csproj`.
- Remove any `net9.0`-specific conditions/guards that become dead code as a result.
- Verify with `dotnet buildcheck`, `dotnet build`, and `dotnet test`.

This PR currently contains only a placeholder CHANGELOG.md entry; the implementation work follows in subsequent commits on this branch.

Closes #170