### PR TITLE
chore: fix missing end-of-file newlines in .csproj files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - AOT-friendly database migration runner, PostgreSQL/SQL Server providers, and a source generator for compile-time SQL migrations
 ### Fixed
+- Ensured .csproj files end with a trailing newline
 ### Changed
 - Dropped net9.0 support: projects now target net10.0 only
 ### Deprecated


### PR DESCRIPTION
## Summary

Verifies and, if needed, fixes the 12 `.csproj` files flagged by the mandatory pre-commit baseline check (`end-of-file-fixer`) as missing a trailing newline at end-of-file.

This PR currently contains only a placeholder CHANGELOG.md entry; the verification/fix work follows in subsequent commits per the approved implementation plan on this issue.

Closes #172

## Test plan

- [ ] `pre-commit run --all-files` (in particular `end-of-file-fixer`) passes with no further modifications
- [ ] `dotnet build` remains green